### PR TITLE
fix: build.gradle dependency resolution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,13 @@ android {
     }
 }
 
+allprojects {
+    repositories {
+        mavenCentral()
+        maven { url "https://api.xposed.info/" }
+    }
+}
+
 dependencies {
     compileOnly 'de.robv.android.xposed:api:82'
 }


### PR DESCRIPTION
When I tried to build, I got the following error:
```
❯ .\gradlew.bat :app:android
Starting a Gradle Daemon, 2 incompatible and 1 stopped Daemons could not be reused, use --status for details

> Task :app:androidDependencies FAILED
debug

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:androidDependencies'.
> Could not resolve all artifacts for configuration ':app:debugCompileClasspath'.
   > Could not find de.robv.android.xposed:api:82.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/de/robv/android/xposed/api/82/api-82.pom
       - https://repo.maven.apache.org/maven2/de/robv/android/xposed/api/82/api-82.pom
       - https://jcenter.bintray.com/de/robv/android/xposed/api/82/api-82.pom
     Required by:
         project :app
```
Adding this to `build.gradle` fixed the dependency resolution.